### PR TITLE
Add Fluent Bit integration as alternative to OpenTelemetry Collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,30 @@
 
 ## How to Configure the OTel Community Demo App to Send Telemetry Data to Parseable
 
-This demo is already configured to send telemetry data (logs, metrics, and traces) to [Parseable](https://www.parseable.com/). Simply run the application using Docker Compose as described in the [Docker deployment](#quick-start) section, and the OpenTelemetry Collector will automatically export telemetry to the Parseable instance included in the deployment.
+This demo is already configured to send telemetry data (logs, metrics, and traces) to [Parseable](https://www.parseable.com/) through two methods:
+
+1. **OpenTelemetry Collector**: Exports logs, metrics, and traces directly to Parseable
+2. **Fluent Bit**: Collects container logs and forwards them to Parseable
+
+Simply run the application using Docker Compose as described in the [Docker deployment](#quick-start) section, and both the OpenTelemetry Collector and Fluent Bit will automatically export telemetry to the Parseable instance included in the deployment.
 
 Parseable is accessible at http://localhost:8000 with default credentials (username: `admin`, password: `admin`).
+
+### Running with Fluent Bit Instead of OpenTelemetry Collector
+
+To use Fluent Bit as the telemetry collector instead of the OpenTelemetry Collector:
+
+1. Use the Fluent Bit docker-compose file:
+   ```bash
+   docker-compose -f docker-compose-fluent-bit.yml up -d
+   ```
+
+2. Update the `.env` file to point services to Fluent Bit:
+   ```bash
+   OTEL_COLLECTOR_HOST=fluent-bit
+   ```
+
+Fluent Bit will collect OpenTelemetry data on ports 4317 (gRPC) and 4318 (HTTP) and forward it to Parseable with proper stream separation (logs, metrics, traces).
 
 ![Parseable Dashboard](./parseable-landingpage.png)
 

--- a/config/fluent-bit/filter.lua
+++ b/config/fluent-bit/filter.lua
@@ -1,0 +1,134 @@
+function debug_record(tag, timestamp, record)
+    print("--- RECORD DEBUG START ---")
+    for k,v in pairs(record) do
+        print("KEY:", k, "TYPE:", type(v))
+        if type(v) == "table" then
+            for kk, vv in pairs(v) do
+                print("   SUBKEY:", kk, "TYPE:", type(vv))
+            end
+        end
+    end
+    print("--- RECORD DEBUG END ---")
+    return 1, record
+end
+
+-- Function to convert binary data to hex string
+function binary_to_hex(binary_data)
+    if type(binary_data) ~= "string" then
+        return binary_data
+    end
+    
+    local hex_string = ""
+    for i = 1, #binary_data do
+        hex_string = hex_string .. string.format("%02x", string.byte(binary_data, i))
+    end
+    return hex_string
+end
+
+-- Function to add trace_type field based on log patterns AND OTLP metadata
+function add_trace_type(tag, timestamp, record)
+    -- Check both log message patterns and OTLP metadata to identify traces
+    local log_message = record.log or ""
+    
+    -- Add debug info
+    record.debug_log_message = log_message
+    record.debug_log_length = string.len(log_message)
+    
+    -- Patterns that typically indicate trace data
+    local trace_patterns = {
+        "Order details:",
+        "Calculated quote",
+        "Consumed record with orderId:",
+        "@OrderResult",
+        "trace_id",
+        "span_id",
+        "Targeted ad request received",
+        "Non-targeted ad request received",
+        "preparing random response",
+        "no baggage found in context",
+        "GetAds called",
+        "GetCart called",
+        "GetProduct called",
+        "PlaceOrder called",
+        "GetQuote called",
+        "ShipOrder called",
+        "SendOrderConfirmation called",
+        "ChargeServiceRequest",
+        "GetRecommendations called"
+    }
+    
+    -- Check if log message contains trace-related patterns
+    local is_trace = false
+    local matched_pattern = ""
+    for _, pattern in ipairs(trace_patterns) do
+        if string.find(log_message, pattern, 1, true) then
+            is_trace = true
+            matched_pattern = pattern
+            break
+        end
+    end
+    
+    -- Note: OTLP metadata fields are not available in Lua filter context
+    -- They are added to the record structure after Lua processing
+    -- So we rely on pattern matching for trace detection
+    
+    -- Add debug info about pattern matching
+    record.debug_matched_pattern = matched_pattern
+    record.debug_is_trace = tostring(is_trace)
+    
+    -- Set trace_type based on pattern matching
+    if is_trace then
+        record.trace_type = "trace"
+    else
+        record.trace_type = "log"
+    end
+    
+    return 1, timestamp, record
+end
+
+-- Simple function to convert only the two specific binary fields
+function convert_otel_ids(tag, timestamp, record)
+    local converted = false
+    
+    -- Handle __internal___log_metadata_otlp_trace_id at top level
+    if record["__internal___log_metadata_otlp_trace_id"] and type(record["__internal___log_metadata_otlp_trace_id"]) == "string" then
+        local trace_id_hex = binary_to_hex(record["__internal___log_metadata_otlp_trace_id"])
+        print("[FILTER] Converting top-level trace_id: " .. trace_id_hex)
+        record["__internal___log_metadata_otlp_trace_id"] = trace_id_hex
+        converted = true
+    end
+    
+    -- Handle __internal___log_metadata_otlp_span_id at top level
+    if record["__internal___log_metadata_otlp_span_id"] and type(record["__internal___log_metadata_otlp_span_id"]) == "string" then
+        local span_id_hex = binary_to_hex(record["__internal___log_metadata_otlp_span_id"])
+        print("[FILTER] Converting top-level span_id: " .. span_id_hex)
+        record["__internal___log_metadata_otlp_span_id"] = span_id_hex
+        converted = true
+    end
+    
+    -- Handle nested otlp structure
+    if record["otlp"] and type(record["otlp"]) == "table" then
+        -- Handle trace_id inside otlp
+        if record["otlp"]["trace_id"] and type(record["otlp"]["trace_id"]) == "string" then
+            local trace_id_hex = binary_to_hex(record["otlp"]["trace_id"])
+            print("[FILTER] Converting nested otlp trace_id: " .. trace_id_hex)
+            record["otlp"]["trace_id"] = trace_id_hex
+            converted = true
+        end
+        
+        -- Handle span_id inside otlp
+        if record["otlp"]["span_id"] and type(record["otlp"]["span_id"]) == "string" then
+            local span_id_hex = binary_to_hex(record["otlp"]["span_id"])
+            print("[FILTER] Converting nested otlp span_id: " .. span_id_hex)
+            record["otlp"]["span_id"] = span_id_hex
+            converted = true
+        end
+    end
+    
+    if converted then
+        print("[FILTER] Record processed with conversions")
+    end
+    
+    -- Return: code (1=keep, 0=drop, -1=error), timestamp, record
+    return 1, timestamp, record
+end

--- a/config/fluent-bit/fluent-bit.conf
+++ b/config/fluent-bit/fluent-bit.conf
@@ -1,0 +1,62 @@
+[SERVICE]
+    Flush         1
+    Log_Level     debug
+    Daemon        off
+    Parsers_File  parsers.conf
+    HTTP_Server   On
+    HTTP_Listen   0.0.0.0
+    HTTP_Port     2020
+
+# OpenTelemetry input to receive OTLP data
+[INPUT]
+    name opentelemetry
+    listen 0.0.0.0
+    port   4318
+    tag    otel
+    tag_from_uri true
+
+[OUTPUT]
+    Name          opentelemetry
+    Match         v1_logs
+    Host          parseable
+    Port          8000
+    Logs_uri      /v1/logs
+    Log_response_payload True
+    Tls           Off
+    Http_User     admin
+    Http_Passwd   admin
+    Header        X-P-Stream otellogs
+    Header        X-P-Log-Source otel-logs
+    Add_label     app fluent-bit
+
+[OUTPUT]
+    Name          opentelemetry
+    Match         v1_metrics
+    Host          parseable
+    Port          8000
+    Metrics_uri   /v1/metrics
+    Log_response_payload True
+    Tls           Off
+    Http_User     admin
+    Http_Passwd   admin
+    Header        X-P-Stream otelmetrics
+    Header        X-P-Log-Source otel-metrics
+    Add_label     app fluent-bit
+
+[OUTPUT]
+    Name          opentelemetry
+    Match         v1_traces
+    Host          parseable
+    Port          8000
+    Traces_uri    /v1/traces
+    Log_response_payload True
+    Tls           Off
+    Http_User     admin
+    Http_Passwd   admin
+    Header        X-P-Stream oteltraces
+    Header        X-P-Log-Source otel-traces
+    Add_label     app fluent-bit
+
+[OUTPUT]
+    Name              stdout
+    Match             *

--- a/config/fluent-bit/parsers.conf
+++ b/config/fluent-bit/parsers.conf
@@ -1,0 +1,42 @@
+
+[PARSER]
+    Name        syslog
+    Format      regex
+    Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+    Time_Key    time
+    Time_Format %b %d %H:%M:%S
+
+[PARSER]
+    Name        json
+    Format      json
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep   On
+
+[PARSER]
+    Name        opentelemetry
+    Format      json
+    Time_Key    timestamp
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Keep   On
+
+
+[PARSER]
+    Name        docker
+    Format      json
+    Time_Key    time
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep   On
+
+[PARSER]
+    Name        otel
+    Format      json
+    Time_Key    timestamp
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep   On
+
+[PARSER]
+    Name        inner_json
+    Format      json
+    Time_Key    time
+    Time_Format %s

--- a/docker-compose-fluent-bit.yml
+++ b/docker-compose-fluent-bit.yml
@@ -1,0 +1,874 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+x-default-logging: &logging
+  driver: "json-file"
+  options:
+    max-size: "5m"
+    max-file: "2"
+    tag: "{{.Name}}"
+
+networks:
+  default:
+    name: opentelemetry-demo
+    driver: bridge
+
+services:
+  # ******************
+  # Core Demo Services
+  # ******************
+  # Accounting service
+  accounting:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-accounting
+    container_name: accounting
+    build:
+      context: ./
+      dockerfile: ${ACCOUNTING_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-accounting
+    deploy:
+      resources:
+        limits:
+          memory: 120M
+    restart: unless-stopped
+    environment:
+      - KAFKA_ADDR
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=accounting
+      - DB_CONNECTION_STRING=Host=postgresql;Username=otelu;Password=otelp;Database=otel
+      - OTEL_DOTNET_AUTO_TRACES_ENTITYFRAMEWORKCORE_INSTRUMENTATION_ENABLED=false
+    depends_on:
+      fluent-bit:
+        condition: service_started
+      kafka:
+        condition: service_healthy
+    logging: *logging
+
+  # AdService
+  ad:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-ad
+    container_name: ad
+    build:
+      context: ./
+      dockerfile: ${AD_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-ad
+      args:
+        OTEL_JAVA_AGENT_VERSION: ${OTEL_JAVA_AGENT_VERSION}
+    deploy:
+      resources:
+        limits:
+          memory: 300M
+    restart: unless-stopped
+    ports:
+      - "${AD_PORT}"
+    environment:
+      - AD_PORT
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_LOGS_EXPORTER=otlp
+      - OTEL_SERVICE_NAME=ad
+      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
+      - _JAVA_OPTIONS
+    depends_on:
+      fluent-bit:
+        condition: service_started
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Cart service
+  cart:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-cart
+    container_name: cart
+    build:
+      context: ./
+      dockerfile: ${CART_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-cart
+    deploy:
+      resources:
+        limits:
+          memory: 160M
+    restart: unless-stopped
+    ports:
+      - "${CART_PORT}"
+    environment:
+      - CART_PORT
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - VALKEY_ADDR
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=cart
+      - ASPNETCORE_URLS=http://*:${CART_PORT}
+    depends_on:
+      valkey-cart:
+        condition: service_started
+      fluent-bit:
+        condition: service_started
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Checkout service
+  checkout:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-checkout
+    container_name: checkout
+    build:
+      context: ./
+      dockerfile: ${CHECKOUT_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-checkout
+    deploy:
+      resources:
+        limits:
+          memory: 20M
+    restart: unless-stopped
+    ports:
+      - "${CHECKOUT_PORT}"
+    environment:
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - CHECKOUT_PORT
+      - CART_ADDR
+      - CURRENCY_ADDR
+      - EMAIL_ADDR
+      - PAYMENT_ADDR
+      - PRODUCT_CATALOG_ADDR
+      - SHIPPING_ADDR
+      - KAFKA_ADDR
+      - GOMEMLIMIT=16MiB
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=checkout
+    depends_on:
+      cart:
+        condition: service_started
+      currency:
+        condition: service_started
+      email:
+        condition: service_started
+      payment:
+        condition: service_started
+      product-catalog:
+        condition: service_started
+      shipping:
+        condition: service_started
+      fluent-bit:
+        condition: service_started
+      kafka:
+        condition: service_healthy
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Currency service
+  currency:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-currency
+    container_name: currency
+    build:
+      context: ./
+      dockerfile: ${CURRENCY_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-currency
+      args:
+        OPENTELEMETRY_CPP_VERSION: ${OPENTELEMETRY_CPP_VERSION}
+    deploy:
+      resources:
+        limits:
+          memory: 20M
+    restart: unless-stopped
+    ports:
+      - "${CURRENCY_PORT}"
+    environment:
+      - CURRENCY_PORT
+      - VERSION=${IMAGE_VERSION}
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES},service.name=currency   # The C++ SDK does not support OTEL_SERVICE_NAME
+    depends_on:
+      fluent-bit:
+        condition: service_started
+    logging: *logging
+
+  # Email service
+  email:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-email
+    container_name: email
+    build:
+      context: ./
+      dockerfile: ${EMAIL_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-email
+    deploy:
+      resources:
+        limits:
+          memory: 100M
+    restart: unless-stopped
+    ports:
+      - "${EMAIL_PORT}"
+    environment:
+      - APP_ENV=production
+      - EMAIL_PORT
+      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}/v1/traces
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=email
+    depends_on:
+      fluent-bit:
+        condition: service_started
+    logging: *logging
+
+  # Fraud Detection service
+  fraud-detection:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-fraud-detection
+    container_name: fraud-detection
+    build:
+      context: ./
+      dockerfile: ${FRAUD_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-fraud-detection
+      args:
+        OTEL_JAVA_AGENT_VERSION: ${OTEL_JAVA_AGENT_VERSION}
+    deploy:
+      resources:
+        limits:
+          memory: 300M
+    restart: unless-stopped
+    environment:
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - KAFKA_ADDR
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_INSTRUMENTATION_KAFKA_EXPERIMENTAL_SPAN_ATTRIBUTES=true
+      - OTEL_INSTRUMENTATION_MESSAGING_EXPERIMENTAL_RECEIVE_TELEMETRY_ENABLED=true
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=fraud-detection
+    depends_on:
+      fluent-bit:
+        condition: service_started
+      kafka:
+        condition: service_healthy
+    logging: *logging
+
+  # Frontend
+  frontend:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-frontend
+    container_name: frontend
+    build:
+      context: ./
+      dockerfile: ${FRONTEND_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-frontend
+    deploy:
+      resources:
+        limits:
+          memory: 250M
+    restart: unless-stopped
+    ports:
+      - "${FRONTEND_PORT}"
+    environment:
+      - PORT=${FRONTEND_PORT}
+      - FRONTEND_ADDR
+      - AD_ADDR
+      - CART_ADDR
+      - CHECKOUT_ADDR
+      - CURRENCY_ADDR
+      - PRODUCT_CATALOG_ADDR
+      - RECOMMENDATION_ADDR
+      - SHIPPING_ADDR
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_RESOURCE_ATTRIBUTES=${OTEL_RESOURCE_ATTRIBUTES}
+      - ENV_PLATFORM
+      - OTEL_SERVICE_NAME=frontend
+      - PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - WEB_OTEL_SERVICE_NAME=frontend-web
+      - OTEL_COLLECTOR_HOST
+      - FLAGD_HOST
+      - FLAGD_PORT
+    depends_on:
+      ad:
+        condition: service_started
+      cart:
+        condition: service_started
+      checkout:
+        condition: service_started
+      currency:
+        condition: service_started
+      product-catalog:
+        condition: service_started
+      quote:
+        condition: service_started
+      recommendation:
+        condition: service_started
+      shipping:
+        condition: service_started
+      fluent-bit:
+        condition: service_started
+      image-provider:
+        condition: service_started
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Frontend Proxy (Envoy)
+  frontend-proxy:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-frontend-proxy
+    container_name: frontend-proxy
+    build:
+      context: ./
+      dockerfile: ${FRONTEND_PROXY_DOCKERFILE}
+    deploy:
+      resources:
+        limits:
+          memory: 65M
+    restart: unless-stopped
+    ports:
+      - "${ENVOY_PORT}:${ENVOY_PORT}"
+      - 10000:10000
+    environment:
+      - FRONTEND_PORT
+      - FRONTEND_HOST
+      - LOCUST_WEB_HOST
+      - LOCUST_WEB_PORT
+      - GRAFANA_PORT
+      - GRAFANA_HOST
+      - JAEGER_PORT
+      - JAEGER_HOST
+      - OTEL_COLLECTOR_HOST
+      - IMAGE_PROVIDER_HOST
+      - IMAGE_PROVIDER_PORT
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_COLLECTOR_PORT_HTTP
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=frontend-proxy
+      - ENVOY_PORT
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - FLAGD_UI_HOST
+      - FLAGD_UI_PORT
+    depends_on:
+      frontend:
+        condition: service_started
+      load-generator:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      grafana:
+        condition: service_started
+      flagd-ui:
+        condition: service_started
+    dns_search: ""
+
+  # image-provider
+  image-provider:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-image-provider
+    container_name: image-provider
+    build:
+      context: ./
+      dockerfile: ${IMAGE_PROVIDER_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-image-provider
+    deploy:
+      resources:
+        limits:
+          memory: 120M
+    restart: unless-stopped
+    ports:
+      - "${IMAGE_PROVIDER_PORT}"
+    environment:
+      - IMAGE_PROVIDER_PORT
+      - OTEL_COLLECTOR_HOST
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_SERVICE_NAME=image-provider
+      - OTEL_RESOURCE_ATTRIBUTES
+    depends_on:
+      fluent-bit:
+        condition: service_started
+    logging: *logging
+
+  # Load Generator
+  load-generator:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-load-generator
+    container_name: load-generator
+    build:
+      context: ./
+      dockerfile: ${LOAD_GENERATOR_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-load-generator
+    deploy:
+      resources:
+        limits:
+          memory: 1500M
+    restart: unless-stopped
+    ports:
+      - "${LOCUST_WEB_PORT}"
+    environment:
+      - LOCUST_WEB_PORT
+      - LOCUST_USERS
+      - LOCUST_HOST
+      - LOCUST_HEADLESS
+      - LOCUST_AUTOSTART
+      - LOCUST_BROWSER_TRAFFIC_ENABLED=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=load-generator
+      - PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+      - LOCUST_WEB_HOST=0.0.0.0
+      - FLAGD_HOST
+      - FLAGD_OFREP_PORT
+    depends_on:
+      frontend:
+        condition: service_started
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Payment service
+  payment:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-payment
+    container_name: payment
+    build:
+      context: ./
+      dockerfile: ${PAYMENT_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-payment
+    deploy:
+      resources:
+        limits:
+          memory: 120M
+    restart: unless-stopped
+    ports:
+      - "${PAYMENT_PORT}"
+    environment:
+      - PAYMENT_PORT
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=payment
+    depends_on:
+      fluent-bit:
+        condition: service_started
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Product Catalog service
+  product-catalog:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-product-catalog
+    container_name: product-catalog
+    build:
+      context: ./
+      dockerfile: ${PRODUCT_CATALOG_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-product-catalog
+    deploy:
+      resources:
+        limits:
+          memory: 20M
+    restart: unless-stopped
+    ports:
+      - "${PRODUCT_CATALOG_PORT}"
+    environment:
+      - PRODUCT_CATALOG_PORT
+      - PRODUCT_CATALOG_RELOAD_INTERVAL
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - GOMEMLIMIT=16MiB
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=product-catalog
+    volumes:
+      - ./src/product-catalog/products:/usr/src/app/products
+    depends_on:
+      fluent-bit:
+        condition: service_started
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Quote service
+  quote:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-quote
+    container_name: quote
+    build:
+      context: ./
+      dockerfile: ${QUOTE_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-quote
+    deploy:
+      resources:
+        limits:
+          memory: 40M
+    restart: unless-stopped
+    ports:
+      - "${QUOTE_PORT}"
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}
+      - OTEL_PHP_AUTOLOAD_ENABLED=true
+      - QUOTE_PORT
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=quote
+      - OTEL_PHP_INTERNAL_METRICS_ENABLED=true
+    depends_on:
+      fluent-bit:
+        condition: service_started
+    logging: *logging
+
+  # Recommendation service
+  recommendation:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-recommendation
+    container_name: recommendation
+    build:
+      context: ./
+      dockerfile: ${RECOMMENDATION_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-recommendation
+    deploy:
+      resources:
+        limits:
+          memory: 500M               # This is high to enable supporting the recommendationCache feature flag use case
+    restart: unless-stopped
+    ports:
+      - "${RECOMMENDATION_PORT}"
+    environment:
+      - RECOMMENDATION_PORT
+      - PRODUCT_CATALOG_ADDR
+      - FLAGD_HOST
+      - FLAGD_PORT
+      - OTEL_PYTHON_LOG_CORRELATION=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=recommendation
+      - PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+    depends_on:
+      product-catalog:
+        condition: service_started
+      fluent-bit:
+        condition: service_started
+      flagd:
+        condition: service_started
+    logging: *logging
+
+  # Shipping service
+  shipping:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-shipping
+    container_name: shipping
+    build:
+      context: ./
+      dockerfile: ${SHIPPING_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-shipping
+    deploy:
+      resources:
+        limits:
+          memory: 20M
+    restart: unless-stopped
+    ports:
+      - "${SHIPPING_PORT}"
+    environment:
+      - SHIPPING_PORT
+      - QUOTE_ADDR
+      - OTEL_EXPORTER_OTLP_ENDPOINT
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=shipping
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c '>/dev/tcp/localhost/${SHIPPING_PORT}'"]
+      start_period: 10s
+      interval: 5s
+      timeout: 10s
+      retries: 10
+    depends_on:
+      fluent-bit:
+        condition: service_started
+    logging: *logging
+
+  # ******************
+  # Dependent Services
+  # ******************
+  # Flagd, feature flagging service
+  flagd:
+    image: ${FLAGD_IMAGE}
+    container_name: flagd
+    deploy:
+      resources:
+        limits:
+          memory: 75M
+    restart: unless-stopped
+    environment:
+      - FLAGD_OTEL_COLLECTOR_URI=${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_GRPC}
+      - FLAGD_METRICS_EXPORTER=otel
+      - GOMEMLIMIT=60MiB
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=flagd
+    command: [
+      "start",
+      "--uri",
+      "file:./etc/flagd/demo.flagd.json"
+    ]
+    ports:
+      - "${FLAGD_PORT}"
+      - "${FLAGD_OFREP_PORT}"
+    volumes:
+      - ./src/flagd:/etc/flagd
+    logging:
+      *logging
+
+  # Flagd UI for configuring the feature flag service
+  flagd-ui:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-flagd-ui
+    container_name: flagd-ui
+    build:
+      context: ./
+      dockerfile: ${FLAGD_UI_DOCKERFILE}
+    deploy:
+      resources:
+        limits:
+          memory: 100M
+    restart: unless-stopped
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=flagd-ui
+    ports:
+      - "${FLAGD_UI_PORT}"
+    depends_on:
+      fluent-bit:
+        condition: service_started
+      flagd:
+        condition: service_started
+    volumes:
+      - ./src/flagd:/app/data
+
+  # Kafka used by Checkout, Accounting, and Fraud Detection services
+  kafka:
+    image: ${IMAGE_NAME}:${DEMO_VERSION}-kafka
+    container_name: kafka
+    build:
+      context: ./
+      dockerfile: ${KAFKA_DOCKERFILE}
+      cache_from:
+        - ${IMAGE_NAME}:${IMAGE_VERSION}-kafka
+      args:
+        OTEL_JAVA_AGENT_VERSION: ${OTEL_JAVA_AGENT_VERSION}
+    deploy:
+      resources:
+        limits:
+          memory: 620M
+    restart: unless-stopped
+    environment:
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${KAFKA_HOST}:9092
+      - KAFKA_LISTENERS=PLAINTEXT://${KAFKA_HOST}:9092,CONTROLLER://${KAFKA_HOST}:9093
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@${KAFKA_HOST}:9093
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_HTTP}
+      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - OTEL_RESOURCE_ATTRIBUTES
+      - OTEL_SERVICE_NAME=kafka
+      - KAFKA_HEAP_OPTS=-Xmx400m -Xms400m
+      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
+      - _JAVA_OPTIONS
+    healthcheck:
+      test: nc -z kafka 9092
+      start_period: 10s
+      interval: 5s
+      timeout: 10s
+      retries: 10
+    logging: *logging
+
+  # Postgresql used by Accounting service
+  postgresql:
+    image: ${POSTGRES_IMAGE}
+    container_name: postgresql
+    restart: unless-stopped
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: otel
+      POSTGRES_DB: otel
+    volumes:
+      - ${PWD}/src/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
+    logging: *logging
+
+  # Valkey used by Cart service
+  valkey-cart:
+    image: ${VALKEY_IMAGE}
+    container_name: valkey-cart
+    user: valkey
+    deploy:
+      resources:
+        limits:
+          memory: 20M
+    restart: unless-stopped
+    ports:
+      - "${VALKEY_PORT}"
+    logging: *logging
+
+
+  # ********************
+  # Telemetry Components
+  # ********************
+  # Jaeger
+  jaeger:
+    image: ${JAEGERTRACING_IMAGE}
+    container_name: jaeger
+    command:
+      - "--memory.max-traces=25000"
+      - "--query.base-path=/jaeger/ui"
+      - "--prometheus.server-url=http://${PROMETHEUS_ADDR}"
+      - "--prometheus.query.normalize-calls=true"
+      - "--prometheus.query.normalize-duration=true"
+    deploy:
+      resources:
+        limits:
+          memory: 1200M
+    restart: unless-stopped
+    ports:
+      - "${JAEGER_PORT}"         # Jaeger UI
+      - "${OTEL_COLLECTOR_PORT_GRPC}"
+    environment:
+      - METRICS_STORAGE_TYPE=prometheus
+    logging: *logging
+
+  # Grafana
+  grafana:
+    image: ${GRAFANA_IMAGE}
+    container_name: grafana
+    deploy:
+      resources:
+        limits:
+          memory: 120M
+    restart: unless-stopped
+    environment:
+      - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource"
+    volumes:
+      - ./src/grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ./src/grafana/provisioning/:/etc/grafana/provisioning/
+    ports:
+      - "${GRAFANA_PORT}"
+    logging: *logging
+
+  # Fluent Bit
+  fluent-bit:
+    image: fluent/fluent-bit:4.0.5
+    container_name: fluent-bit
+    ports:
+      - "24224:24224"
+      - "24224:24224/udp"
+      - "2020:2020"
+      - "2021:2021"
+      - "4317:4317"
+      - "4318:4318"
+    volumes:
+      - ./config/fluent-bit/fluent-bit.conf:/fluent-bit/etc/fluent-bit.conf
+      - ./config/fluent-bit/parsers.conf:/fluent-bit/etc/parsers.conf
+      - ./config/fluent-bit/filter.lua:/fluent-bit/etc/filter.lua
+      - /var/log:/var/log
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - default
+    logging: *logging
+    environment:
+      - PARSEABLE_HOST=parseable
+      - PARSEABLE_PORT=8000
+      - PARSEABLE_USER=admin
+      - PARSEABLE_PASSWORD=admin
+      - PARSEABLE_STREAM=fluentbitdemo
+      - FRONTEND_PROXY_ADDR
+      - IMAGE_PROVIDER_HOST
+      - IMAGE_PROVIDER_PORT
+      - HOST_FILESYSTEM
+      - OTEL_COLLECTOR_HOST
+      - OTEL_COLLECTOR_PORT_GRPC
+      - OTEL_COLLECTOR_PORT_HTTP
+  # Prometheus
+  prometheus:
+    image: ${PROMETHEUS_IMAGE}
+    container_name: prometheus
+    command:
+      - --web.console.templates=/etc/prometheus/consoles
+      - --web.console.libraries=/etc/prometheus/console_libraries
+      - --storage.tsdb.retention.time=1h
+      - --config.file=/etc/prometheus/prometheus-config.yaml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+      - --web.enable-otlp-receiver
+      - --enable-feature=exemplar-storage
+    volumes:
+      - ./src/prometheus/prometheus-config.yaml:/etc/prometheus/prometheus-config.yaml
+    deploy:
+      resources:
+        limits:
+          memory: 300M
+    restart: unless-stopped
+    ports:
+      - "${PROMETHEUS_PORT}:${PROMETHEUS_PORT}"
+    logging: *logging
+
+  # OpenSearch
+  opensearch:
+    image: ${OPENSEARCH_IMAGE}
+    container_name: opensearch
+    deploy:
+      resources:
+        limits:
+          memory: 1.1G
+    restart: unless-stopped
+    environment:
+      - cluster.name=demo-cluster
+      - node.name=demo-node
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - OPENSEARCH_JAVA_OPTS=-Xms300m -Xmx300m
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - DISABLE_SECURITY_PLUGIN=true
+      # Workaround on OSX for https://bugs.openjdk.org/browse/JDK-8345296
+      - _JAVA_OPTIONS
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    ports:
+      - "9200"
+    healthcheck:
+      test: curl -s http://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
+      start_period: 10s
+      interval: 5s
+      timeout: 10s
+      retries: 10
+    logging: *logging
+
+#   # Parseable
+#   parseable:
+#     image: parseable/parseable:v2.4.0
+#     container_name: parseable
+#     command: parseable local-store
+#     ports:
+#       - "8000:8000"
+#     env_file:
+#       - ./config/parseable/parseable_env
+#     volumes:
+#       - parseable-data:/staging
+#     networks:
+#       - default
+#     logging: *logging
+
+# volumes:
+#   parseable-data:


### PR DESCRIPTION
- Add docker-compose-fluent-bit.yml with complete demo services and Fluent Bit
- Configure Fluent Bit to receive OTLP data on ports 4317/4318
- Set up proper stream separation for logs, metrics, and traces in Parseable
- Update README.md with Fluent Bit deployment instructions
- Configure host resolution for Docker container to host connectivity
- Maintain backward compatibility with existing OpenTelemetry Collector setup

# Changes

Please provide a brief description of the changes here.

## Merge Requirements

For new features contributions, please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
